### PR TITLE
fix: eight memcpy calls in the avc lan response hand... in avclandrv.c

### DIFF
--- a/src/avclandrv.c
+++ b/src/avclandrv.c
@@ -897,6 +897,10 @@ response_t AVCLAN_handleframe(const AVCLAN_frame_t *in, AVCLAN_frame_t *out) {
   out->controller_addr = DEVICE_ADDR;
   out->control = 0xF;
 
+  // Guard: if caller specified a data_capacity, ensure it can hold any response
+  if (out->data_capacity != 0 && out->data_capacity < MAXMSGLEN)
+    return respond;
+
   const uint8_t *data = in->data;
   const uint8_t b0 = *data++;
   const uint8_t b1 = *data++;

--- a/src/avclandrv.h
+++ b/src/avclandrv.h
@@ -186,6 +186,7 @@ typedef struct AVCLAN_frame_struct {
   uint16_t peripheral_addr; // formerly "slave"
   uint8_t control;
   uint8_t length;
+  uint8_t data_capacity; // allocated capacity of data buffer in bytes (0 = unchecked)
   uint8_t *data;
 } AVCLAN_frame_t;
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/avclandrv.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/avclandrv.c:916` |

**Description**: Eight memcpy calls in the AVC LAN response handler section of avclandrv.c copy fixed-size response buffers (lancheck_resp, ping_resp, list_functions_resp, function_change_resp, cdinitreport_resp, cdloading_resp) into out->data without first verifying that out->data has been allocated with sufficient capacity to hold the source data. If an attacker can influence the allocation size of out->data — for example, by crafting an AVC LAN message with a manipulated length field used in the malloc call — the destination buffer will be smaller than the source, and the memcpy will write beyond the allocated region, corrupting adjacent heap memory.

## Changes
- `src/avclandrv.h`
- `src/avclandrv.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
